### PR TITLE
Add Random Object Rain sample

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Samples~/Utilities/DestroyOnPickupUse.cs
+++ b/Packages/com.vrchat.UdonSharp/Samples~/Utilities/DestroyOnPickupUse.cs
@@ -1,0 +1,20 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+namespace UdonSharp.Examples.Utilities
+{
+    /// <summary>
+    /// Destroys the object when the user presses the Use button while holding it.
+    /// Requires a VRC_Pickup component on the same GameObject.
+    /// </summary>
+    [AddComponentMenu("Udon Sharp/Utilities/Destroy On Pickup Use")]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
+    public class DestroyOnPickupUse : UdonSharpBehaviour
+    {
+        public override void OnPickupUseDown()
+        {
+            Networking.Destroy(gameObject);
+        }
+    }
+}

--- a/Packages/com.vrchat.UdonSharp/Samples~/Utilities/DestroyOnPickupUse.cs.meta
+++ b/Packages/com.vrchat.UdonSharp/Samples~/Utilities/DestroyOnPickupUse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c51a9fa6ef7a4f8b86cac6d15a848807
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.vrchat.UdonSharp/Samples~/Utilities/RandomObjectRainSpawner.cs
+++ b/Packages/com.vrchat.UdonSharp/Samples~/Utilities/RandomObjectRainSpawner.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using UdonSharp;
+using VRC.SDKBase;
+
+namespace UdonSharp.Examples.Utilities
+{
+    /// <summary>
+    /// Spawns random objects within a defined area and drops them using gravity.
+    /// Objects are spawned via Networking.Instantiate so they appear for all users.
+    /// </summary>
+    [AddComponentMenu("Udon Sharp/Utilities/Random Object Rain Spawner")]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
+    public class RandomObjectRainSpawner : UdonSharpBehaviour
+    {
+        [Tooltip("Prefabs that can be spawned")] public GameObject[] spawnPrefabs;
+        [Tooltip("Size of the spawn area (local space)")] public Vector3 areaSize = new Vector3(5f, 1f, 5f);
+        [Tooltip("Time between spawns in seconds")] public float spawnInterval = 1f;
+        [Tooltip("Number of objects to spawn each interval")] public int spawnCount = 1;
+
+        private float _nextSpawnTime;
+
+        private void Update()
+        {
+            if (spawnPrefabs == null || spawnPrefabs.Length == 0) return;
+            if (Time.time < _nextSpawnTime) return;
+            _nextSpawnTime = Time.time + spawnInterval;
+
+            for (int i = 0; i < spawnCount; i++)
+            {
+                Vector3 randomOffset = new Vector3(
+                    Random.Range(-areaSize.x * 0.5f, areaSize.x * 0.5f),
+                    Random.Range(0f, areaSize.y),
+                    Random.Range(-areaSize.z * 0.5f, areaSize.z * 0.5f));
+
+                Vector3 spawnPos = transform.TransformPoint(randomOffset);
+                GameObject prefab = spawnPrefabs[Random.Range(0, spawnPrefabs.Length)];
+                if (prefab == null) continue;
+
+                GameObject obj = Networking.Instantiate(VRC.SDKBase.VRC_EventHandler.VrcBroadcastType.Always, prefab.name, spawnPos, Quaternion.identity);
+                // Ensure spawned object has rigidbody for physics
+                if (obj.GetComponent<Rigidbody>() == null)
+                {
+                    Rigidbody rb = obj.AddComponent<Rigidbody>();
+                    rb.collisionDetectionMode = CollisionDetectionMode.Continuous;
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.vrchat.UdonSharp/Samples~/Utilities/RandomObjectRainSpawner.cs.meta
+++ b/Packages/com.vrchat.UdonSharp/Samples~/Utilities/RandomObjectRainSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7b432bfd1f847809419122826b5c299
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add RandomObjectRainSpawner for spawning synced falling objects
- add DestroyOnPickupUse behaviour for removing objects with use

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b0c533e0483328dfadbfe84652d80